### PR TITLE
fix: wait for Roblox processes to exit and retry directory move on IOException

### DIFF
--- a/src/Sirstrap.Core/IncognitoManager.cs
+++ b/src/Sirstrap.Core/IncognitoManager.cs
@@ -2,10 +2,10 @@ namespace Sirstrap.Core
 {
     public static class IncognitoManager
     {
-        private static readonly string _robloxFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Roblox");
         private static readonly string _incognitoCachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Sirstrap", "IncognitoCache", "Roblox");
         private static bool _isRobloxFolderMoved = false;
         private static readonly Lock _lockObject = new();
+        private static readonly string _robloxFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Roblox");
 
         static IncognitoManager()
         {
@@ -58,9 +58,11 @@ namespace Sirstrap.Core
                         _incognitoCachePath.BetterDirectoryDelete();
                     }
 
+                    SingletonManager.WaitForAllRobloxProcessesToExit();
+
                     Log.Information("[*] Moving Roblox folder to Incognito cache: {0} -> {1}", _robloxFolderPath, _incognitoCachePath);
 
-                    Directory.Move(_robloxFolderPath, _incognitoCachePath);
+                    _robloxFolderPath.BetterDirectoryMove(_incognitoCachePath);
 
                     _isRobloxFolderMoved = true;
 
@@ -110,7 +112,7 @@ namespace Sirstrap.Core
 
                     Log.Information("[*] Restoring Roblox folder from Incognito cache: {0} -> {1}", _incognitoCachePath, _robloxFolderPath);
 
-                    Directory.Move(_incognitoCachePath, _robloxFolderPath);
+                    _incognitoCachePath.BetterDirectoryMove(_robloxFolderPath);
 
                     _isRobloxFolderMoved = false;
 

--- a/src/Sirstrap.Core/StringExtension.cs
+++ b/src/Sirstrap.Core/StringExtension.cs
@@ -58,6 +58,33 @@
             }
         }
 
+        public static void BetterDirectoryMove(this string sourcePath, string destinationPath, int attempts = 5)
+        {
+            try
+            {
+                foreach (int attempt in Enumerable.Range(1, attempts))
+                    try
+                    {
+                        Directory.Move(sourcePath, destinationPath);
+
+                        return;
+                    }
+                    catch (IOException)
+                    {
+                        if (attempt == attempts)
+                            throw;
+
+                        Thread.Sleep(100 * attempt);
+                    }
+            }
+            catch (Exception)
+            {
+                Log.Error("[!] Error moving directory: {0} -> {1}.", sourcePath, destinationPath);
+
+                throw;
+            }
+        }
+
         public static void BetterFileDelete(this string filePath, int attempts = 5)
         {
             try


### PR DESCRIPTION
MoveRobloxFolderToCache() was failing with IOException ("Access to the
path is denied") because Roblox processes killed by CloseAllRobloxInstances()
had not fully released file handles before Directory.Move() was called.

- Add WaitForAllRobloxProcessesToExit() before moving the Roblox folder
  to cache, matching what RestoreRobloxFolderFromCache() already does
- Add BetterDirectoryMove extension method with retry logic (5 attempts,
  100ms * attempt backoff) following the existing BetterDirectoryDelete pattern
- Use BetterDirectoryMove in both MoveRobloxFolderToCache() and
  RestoreRobloxFolderFromCache() for consistent resilience

Fixes #34

Signed-off-by: ギャップ <massimopagani@hotmail.com>