### PR TITLE
fix: check exe file existence instead of directory in IsAlreadyInstalled

### DIFF
--- a/src/Sirstrap.Core/RobloxDownloader.cs
+++ b/src/Sirstrap.Core/RobloxDownloader.cs
@@ -57,7 +57,7 @@
 
         private static bool IsAlreadyInstalled(Configuration configuration)
         {
-            return configuration.BinaryType.Equals("WindowsPlayer", StringComparison.OrdinalIgnoreCase) && Directory.Exists(PathManager.GetExtractionPath(configuration.VersionHash));
+            return configuration.BinaryType.Equals("WindowsPlayer", StringComparison.OrdinalIgnoreCase) && File.Exists(Path.Combine(PathManager.GetExtractionPath(configuration.VersionHash), "RobloxPlayerBeta.exe"));
         }
 
         private static bool LaunchApplication(Configuration configuration)


### PR DESCRIPTION
IsAlreadyInstalled() previously only checked if the version directory
existed, not whether RobloxPlayerBeta.exe was actually present. This
caused false-positive "already installed" detection when the directory
existed but the exe was missing (partial install, corruption, etc.),
triggering a Sentry error before falling through to re-download.

Now checks for the exe file directly, which correctly routes to the
re-download path when the installation is incomplete.

Fixes #37

Signed-off-by: ギャップ <massimopagani@hotmail.com>